### PR TITLE
Fix problem with "Driver [] is not supported."

### DIFF
--- a/src/Console/ClearExpiredCommand.php
+++ b/src/Console/ClearExpiredCommand.php
@@ -35,8 +35,10 @@ class ClearExpiredCommand extends Command
             'driver' => 'local',
             'root' => config('cache.stores.file.path')
         ];
-        config('filesystems.disks.fcache', $cacheDisk);
+
+        config(['filesystems.disks.fcache' => $cacheDisk]);
     }
+
     /**
      * Execute the console command.
      *
@@ -48,6 +50,7 @@ class ClearExpiredCommand extends Command
         $this->deleteEmptyFolders();
         $this->showResults();
     }
+
     private function deleteExpiredFiles()
     {
         $files = Storage::disk('fcache')->allFiles();


### PR DESCRIPTION
The command errors out with "Driver [] is not supported.", the problem seems to be that this call

    config('filesystems.disks.fcache', $cacheDisk);

Doesn't actually set the config, calling the `config()` helper that way just gets the config returning `$cacheDisk` as a default.  To set the config you need to call with a single array as the argument.

After making that small tweak, the command works very nicely.