### PR TITLE
Remove ::newLine() and handle symfony/console constants missing in order to be backwards compatible with Laravel <7

### DIFF
--- a/src/CacheGarbageCollector.php
+++ b/src/CacheGarbageCollector.php
@@ -106,7 +106,7 @@ class CacheGarbageCollector
             $size = $this->activeFiles->getFormattedSize();
             Partyline::info("{$count} ({$size}) cache file remaining.");
         }
-        Partyline::newLine();
+        Partyline::line("\n");
 
         return $this;
     }
@@ -134,7 +134,7 @@ class CacheGarbageCollector
             Partyline::info("{$this->deletedDirectories} empty directories deleted.");
         }
 
-        Partyline::newLine();
+        Partyline::line("\n");
 
         return $this;
     }

--- a/src/ClearExpiredCommand.php
+++ b/src/ClearExpiredCommand.php
@@ -9,6 +9,9 @@ use Wilderborn\Partyline\Facade as Partyline;
 
 class ClearExpiredCommand extends Command
 {
+    public const SUCCESS = 0;
+    public const FAILURE = 1;
+    
     /**
      * @var CacheGarbageCollector
      */


### PR DESCRIPTION
Laravel <7 does not have the `Partyline::newLine()` method, resulting in an error. Replaced with simple `Partyline::line("\n")` to support these versions too.

Additionally, the symfony/console version in tgese version of Laravel does not have the `SUCCESS` or `FAILURE` constants defined, resulting in an error.